### PR TITLE
[ᚬtxn] feat: Implement more traits for ReadOnlyDB

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -81,8 +81,8 @@ mod handle;
 pub mod merge_operator;
 mod open_raw;
 pub mod ops;
-mod optimistic_transaction_db;
 mod optimistic_transaction;
+mod optimistic_transaction_db;
 mod read_only_db;
 mod slice_transform;
 mod snapshot;
@@ -99,20 +99,20 @@ pub use db_iterator::{DBIterator, DBRawIterator, Direction, IteratorMode};
 pub use db_options::{DBCompactionStyle, DBCompressionType, DBRecoveryMode, ReadOptions};
 pub use db_pinnable_slice::DBPinnableSlice;
 pub use db_vector::DBVector;
+pub use handle::{ConstHandle, Handle};
 pub use read_only_db::ReadOnlyDB;
+pub use slice_transform::SliceTransform;
 pub use snapshot::Snapshot;
 pub use util::TemporaryDBPath;
 pub use write_batch::WriteBatch;
-pub use handle::{Handle, ConstHandle};
-pub use slice_transform::SliceTransform;
 
 pub use merge_operator::MergeOperands;
 use std::error;
 use std::fmt;
 
-pub use optimistic_transaction_db::{OptimisticTransactionDB, OptimisticTransactionOptions};
 pub use optimistic_transaction::{OptimisticTransaction, OptimisticTransactionSnapshot};
-pub use transaction::{TransactionSnapshot, Transaction};
+pub use optimistic_transaction_db::{OptimisticTransactionDB, OptimisticTransactionOptions};
+pub use transaction::{Transaction, TransactionSnapshot};
 pub use transaction_db::{TransactionDB, TransactionDBOptions, TransactionOptions};
 
 /// A simple wrapper round a string, used for errors reported from

--- a/src/optimistic_transaction.rs
+++ b/src/optimistic_transaction.rs
@@ -16,9 +16,7 @@ unsafe impl Sync for OptimisticTransaction {}
 
 impl OptimisticTransaction {
     pub(crate) fn new(inner: *mut ffi::rocksdb_transaction_t) -> OptimisticTransaction {
-        OptimisticTransaction {
-            inner,
-        }
+        OptimisticTransaction { inner }
     }
 
     /// commits a transaction

--- a/src/optimistic_transaction_db.rs
+++ b/src/optimistic_transaction_db.rs
@@ -5,17 +5,16 @@ use crate::{
     handle::{ConstHandle, Handle},
     open_raw::{OpenRaw, OpenRawFFI},
     ops::*,
-    ColumnFamily, Error, Transaction, WriteOptions,
-    Options, OptimisticTransaction
+    ColumnFamily, Error, OptimisticTransaction, Options, Transaction, WriteOptions,
 };
 
 use ffi;
+use ffi_util::to_cpath;
 use libc::c_uchar;
 use std::collections::BTreeMap;
 use std::marker::PhantomData;
 use std::path::{Path, PathBuf};
 use std::ptr;
-use ffi_util::to_cpath;
 
 /// A optimistic transaction database.
 pub struct OptimisticTransactionDB {

--- a/tests/test_optimistic_transaction.rs
+++ b/tests/test_optimistic_transaction.rs
@@ -1,8 +1,8 @@
 extern crate rocksdb;
 
 use rocksdb::{
-    prelude::*, MergeOperands, OptimisticTransactionDB, OptimisticTransactionOptions, Options,
-    TemporaryDBPath, WriteOptions, OptimisticTransaction
+    prelude::*, MergeOperands, OptimisticTransaction, OptimisticTransactionDB,
+    OptimisticTransactionOptions, Options, TemporaryDBPath, WriteOptions,
 };
 use std::sync::Arc;
 use std::thread;
@@ -249,9 +249,7 @@ struct TransWrapper {
 
 impl TransWrapper {
     fn new(txn: OptimisticTransaction) -> Self {
-        Self {
-            txn: Arc::new(txn),
-        }
+        Self { txn: Arc::new(txn) }
     }
 
     fn check<K>(&self, key: K, value: &str) -> bool


### PR DESCRIPTION
This  changes add certain missing trait implementations used to actually use read only mode.

Note it also changes the default value of `error_if_log_file_exists` to false, this is because:

* The original implementation doesn't provide a way we can tweak this value
* The [corresponding value](https://github.com/facebook/rocksdb/blob/a3960fc875233308976351f185b672e8f01296ec/include/rocksdb/db.h#L165) in rocksdb is also false by default.

To make sure we make the smallest amount of changes from the upstream version, I just flip the value of the flag here.