### PR TITLE
fix: The `librocksdb-sys`crate need to publish separately

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "ckb-rocksdb"
 description = "Rust wrapper for Facebook's RocksDB embeddable database"
-version = "0.12.2"
+version = "0.12.3"
 authors = ["Tyler Neely <t@jujit.su>", "David Greenberg <dsg123456789@gmail.com>", "Nervos Core Dev <dev@nervos.org>"]
 license = "Apache-2.0"
 keywords = ["database", "embedded", "LSM-tree", "persistence"]
@@ -26,4 +26,4 @@ bzip2 = ["librocksdb-sys/bzip2"]
 
 [dependencies]
 libc = "0.2"
-librocksdb-sys = { path = "librocksdb-sys", version = "6.4.6" }
+librocksdb-sys = { package = "ckb-librocksdb-sys", path = "librocksdb-sys", version = "6.4.6" }

--- a/librocksdb-sys/Cargo.toml
+++ b/librocksdb-sys/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
-name = "librocksdb-sys"
+name = "ckb-librocksdb-sys"
 version = "6.4.6"
-authors = ["Karl Hobley <karlhobley10@gmail.com>", "Arkadiy Paronyan <arkadiy@ethcore.io>"]
+authors = ["Karl Hobley <karlhobley10@gmail.com>", "Arkadiy Paronyan <arkadiy@ethcore.io>", "Nervos Core Dev <dev@nervos.org>"]
 license = "MIT/Apache-2.0/BSD-3-Clause"
 description = "Native bindings to librocksdb"
 readme = "README.md"
-repository = "https://github.com/rust-rocksdb/rust-rocksdb.git"
+repository = "https://github.com/nervosnetwork/rust-rocksdb"
 keywords = [ "ffi", "rocksdb" ]
 
 build = "build.rs"

--- a/librocksdb-sys/tests/ffi.rs
+++ b/librocksdb-sys/tests/ffi.rs
@@ -25,8 +25,8 @@
 
 #[macro_use]
 extern crate const_cstr;
+extern crate ckb_librocksdb_sys as ffi;
 extern crate libc;
-extern crate librocksdb_sys as ffi;
 extern crate uuid;
 
 use ffi::*;


### PR DESCRIPTION
The `librocksdb-sys`crate need to publish separately from the main crate, and must be published first
since the main crate depends on it.