### PR TITLE
feat: impl Handle for Options

### DIFF
--- a/src/db_options.rs
+++ b/src/db_options.rs
@@ -1989,3 +1989,9 @@ impl ConstHandle<ffi::rocksdb_options_t> for Options {
         self.inner
     }
 }
+
+impl Handle<ffi::rocksdb_options_t> for Options {
+    fn handle(&self) -> *mut ffi::rocksdb_options_t {
+        self.inner
+    }
+}


### PR DESCRIPTION
A mutable inner of `Options` is required for using [ those `ffi::rocksdb_options_set_*` methods](https://github.com/nervosnetwork/rust-rocksdb/blob/c317b9915dcc1e05c5ea295bdd893f38f9be130c/librocksdb-sys/src/bindings.rs) in `CKB` directly.
Since there are too many methods (`100+`), wrapping all of them is a bit redundant.