### PR TITLE
Enable opening a TransactionDB with ColumnFamilies

### DIFF
--- a/src/transaction_db.rs
+++ b/src/transaction_db.rs
@@ -39,6 +39,8 @@ impl Handle<ffi::rocksdb_transactiondb_t> for TransactionDB {
 
 impl Open for TransactionDB {}
 
+impl OpenCF for TransactionDB {}
+
 impl OpenRaw for TransactionDB {
     type Pointer = ffi::rocksdb_transactiondb_t;
     type Descriptor = TransactionDBOptions;


### PR DESCRIPTION
Implements the `OpenCF` trait for `TransactionDB`. Am I overlooking something, or was this simply forgotten?