### PR TITLE
fix: fix io uring link

### DIFF
--- a/librocksdb-sys/build.rs
+++ b/librocksdb-sys/build.rs
@@ -14,6 +14,8 @@ fn get_flags_from_detect_platform_script() -> Option<Vec<String>> {
         }
         if cfg!(feature = "io-uring") {
             cmd.env("ROCKSDB_USE_IO_URING", "1");
+        } else {
+            cmd.env("ROCKSDB_USE_IO_URING", "0");
         }
 
         let output = cmd
@@ -148,6 +150,12 @@ fn build_rocksdb() {
     if let Some(flags) = get_flags_from_detect_platform_script() {
         println!("PLATFORM_CXXFLAGS: {:?}", flags);
         for flag in flags {
+            if flag == "-DROCKSDB_IOURING_PRESENT" {
+                // "-luring" not on PLATFORM_CXXFLAGS but on PLATFORM_LDFLAGS
+                // so rust binding build.rs should do it by self
+                config.flag("-luring");
+                println!("cargo:rustc-link-lib=uring");
+            }
             config.flag(&flag);
         }
     } else {


### PR DESCRIPTION
rocksdb [release note](https://github.com/facebook/rocksdb/blob/246d469750d90396ae84ef7627fd526766e85a2e/HISTORY.md#build):
> By default, try to build with liburing. For make, if ROCKSDB_USE_IO_URING is not set, treat as enable, which means RocksDB will try to build with liburing. Users can disable it with ROCKSDB_USE_IO_URING=0. For cmake, add WITH_LIBURING to control it, with default on.

[code](https://github.com/facebook/rocksdb/blob/c73d2a9d18fb8be004f142c0de1a8c8a04c2e181/build_tools/build_detect_platform#L172-L175):
```bash
        if test -z "$ROCKSDB_USE_IO_URING"; then
            ROCKSDB_USE_IO_URING=1
        fi
        if test "$ROCKSDB_USE_IO_URING" -ne 0; then
            # check for liburing
            $CXX $PLATFORM_CXXFLAGS -x c++ - -luring -o test.o 2>/dev/null  <<EOF
              #include <liburing.h>
              int main() {
                struct io_uring ring;
                io_uring_queue_init(1, &ring, 0);
                return 0;
              }
EOF
            if [ "$?" = 0 ]; then
                PLATFORM_LDFLAGS="$PLATFORM_LDFLAGS -luring"
                COMMON_FLAGS="$COMMON_FLAGS -DROCKSDB_IOURING_PRESENT"
            fi
        fi
```

`test -z`: if not set, it will return true

our build.rs if not enable "io-uring" feature, it will always not set
https://github.com/nervosnetwork/rust-rocksdb/blob/fd7ce274b22e894f4a08290bbfe4b26ebe5d5910/librocksdb-sys/build.rs#L15-L18

so, build.rs must set it to 0 when feature is not enabled.

`-luring` will set to `PLATFORM_LDFLAGS` but not `PLATFORM_CXXFLAGS`
https://github.com/nervosnetwork/rust-rocksdb/blob/fd7ce274b22e894f4a08290bbfe4b26ebe5d5910/librocksdb-sys/build.rs#L27

We do not intend to modify the `build_detect_platform` file, so we should modify build.rs, if `DROCKSDB_IOURING_PRESENT` is set, we should set `-luring`