### PR TITLE
chore: public field

### DIFF
--- a/src/column_family.rs
+++ b/src/column_family.rs
@@ -19,8 +19,8 @@ use crate::{handle::Handle, ColumnFamily, Options};
 /// A description of the column family, containing the name and `Options`.
 #[derive(Clone)]
 pub struct ColumnFamilyDescriptor {
-    pub(crate) name: String,
-    pub(crate) options: Options,
+    pub name: String,
+    pub options: Options,
 }
 
 impl ColumnFamilyDescriptor {


### PR DESCRIPTION
In some scenarios we need to fine tune the column family option after loading from config file ( ref: https://github.com/quake/ckb/commit/7620fb52d1e8d0e83e849dbca844b7fe38322197#diff-6dab8e7d25d73eb42d315193abdc62495373a4d6f2bb75c4a22b7decb343f1cfR64-R72 ), but currently the field is private, this PR changes it to public.

