### PR TITLE
chore: Update RocksDB to 8.5.4

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "ckb-rocksdb"
 description = "Rust wrapper for Facebook's RocksDB embeddable database"
-version = "0.21.0"
+version = "0.21.1"
 edition = "2018"
 authors = ["Tyler Neely <t@jujit.su>", "David Greenberg <dsg123456789@gmail.com>", "Nervos Core Dev <dev@nervos.org>"]
 license = "Apache-2.0"
@@ -31,7 +31,7 @@ march-native = ["librocksdb-sys/march-native"]
 
 [dependencies]
 libc = "0.2"
-librocksdb-sys = { package = "ckb-librocksdb-sys", path = "librocksdb-sys", version = "=8.5.3" }
+librocksdb-sys = { package = "ckb-librocksdb-sys", path = "librocksdb-sys", version = "=8.5.4" }
 tempfile = "3"
 
 [dev-dependencies]

--- a/librocksdb-sys/Cargo.toml
+++ b/librocksdb-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ckb-librocksdb-sys"
-version = "8.5.3"
+version = "8.5.4"
 edition = "2018"
 authors = ["Karl Hobley <karlhobley10@gmail.com>", "Arkadiy Paronyan <arkadiy@ethcore.io>", "Nervos Core Dev <dev@nervos.org>"]
 license = "MIT/Apache-2.0/BSD-3-Clause"

--- a/librocksdb-sys/build_version.cc
+++ b/librocksdb-sys/build_version.cc
@@ -8,17 +8,17 @@
 
 // The build script may replace these values with real values based
 // on whether or not GIT is available and the platform settings
-static const std::string rocksdb_build_git_sha  = "rocksdb_build_git_sha:f32521662acf3352397d438b732144c7813bbbec";
-static const std::string rocksdb_build_git_tag = "rocksdb_build_git_tag:v8.5.3";
+static const std::string rocksdb_build_git_sha  = "rocksdb_build_git_sha:145a50ba007326eab90da9b12d697b35f5b60e7d";
+static const std::string rocksdb_build_git_tag = "rocksdb_build_git_tag:v8.5.4";
 #define HAS_GIT_CHANGES 0
 #if HAS_GIT_CHANGES == 0
 // If HAS_GIT_CHANGES is 0, the GIT date is used.
 // Use the time the branch/tag was last modified
-static const std::string rocksdb_build_date = "rocksdb_build_date:2023-09-01 13:58:39";
+static const std::string rocksdb_build_date = "rocksdb_build_date:2023-09-26 19:47:02";
 #else
 // If HAS_GIT_CHANGES is > 0, the branch/tag has modifications.
 // Use the time the build was created.
-static const std::string rocksdb_build_date = "rocksdb_build_date:2023-09-21 10:21:22";
+static const std::string rocksdb_build_date = "rocksdb_build_date:2023-10-12 09:08:22";
 #endif
 
 extern "C" {


### PR DESCRIPTION
https://github.com/facebook/rocksdb/releases/tag/v8.5.4

## Bug Fixes
* Fixed a bug where compaction read under non direct IO still falls back to RocksDB internal prefetching after file system's prefetching returns non-OK status other than Status::NotSupported()