### PR TITLE
fix: Bump ckb-rocksdb to 0.22.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ serde1 = ["serde"]
 [dependencies]
 home = "0.5"
 libc = "0.2"
-librocksdb-sys = { package = "ckb-librocksdb-sys", path = "librocksdb-sys", version = "=9.10.1" }
+librocksdb-sys = { package = "ckb-librocksdb-sys", path = "librocksdb-sys", version = "=9.10.2" }
 tempfile = "3"
 serde = { version = "1", features = ["derive"], optional = true }
 

--- a/librocksdb-sys/Cargo.toml
+++ b/librocksdb-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ckb-librocksdb-sys"
-version = "9.10.1"
+version = "9.10.2"
 edition = "2024"
 authors = ["Karl Hobley <karlhobley10@gmail.com>", "Arkadiy Paronyan <arkadiy@ethcore.io>", "Nervos Core Dev <dev@nervos.org>"]
 license = "MIT/Apache-2.0/BSD-3-Clause"


### PR DESCRIPTION
fix https://github.com/nervosnetwork/rust-rocksdb/pull/59