### PR TITLE
bindgen: Downgrade bindgen to 0.69.5 to use build success on clang-10

### DIFF
--- a/librocksdb-sys/Cargo.toml
+++ b/librocksdb-sys/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "ckb-librocksdb-sys"
 version = "9.10.2"
-edition = "2024"
+edition = "2021"
 authors = ["Karl Hobley <karlhobley10@gmail.com>", "Arkadiy Paronyan <arkadiy@ethcore.io>", "Nervos Core Dev <dev@nervos.org>"]
 license = "MIT/Apache-2.0/BSD-3-Clause"
 description = "Native bindings to librocksdb"
@@ -48,7 +48,7 @@ uuid = { version = "1.0", features = ["v4"] }
 
 [build-dependencies]
 cc = { version = "1.0", features = ["parallel"] }
-bindgen = { version = "0.71.1", default-features = false }
+bindgen = { version = "0.69.5", default-features = false }
 glob = "0.3.2"
 pkg-config = "0.3"
 rust-ini = "0.21"

--- a/librocksdb-sys/build.rs
+++ b/librocksdb-sys/build.rs
@@ -6,7 +6,7 @@ use std::fs;
 use std::path::PathBuf;
 use std::process::Command;
 
-const RUST_TARGET: &str = "1.85.0";
+const RUST_TARGET: &str = "1.71";
 
 fn get_flags_from_detect_platform_script() -> Option<Vec<String>> {
     if !cfg!(target_os = "windows") {


### PR DESCRIPTION
If we want to let ckb-rocksdb build successfully on clang-10 platform, then we need to downgrde bindgen to 0.69.5:
Ref:
- https://github.com/rust-lang/rust-bindgen/issues/3169
- https://github.com/rust-lang/rust-bindgen/blob/d0e7d6b5b763e93dd38f9ece05230979ede95a0a/bindgen/Cargo.toml#L32
- https://github.com/rust-lang/rust-bindgen/blob/ddd00d48e27a6451f65fb8afef381d98a56e0560/bindgen/Cargo.toml#L31
