### PR TITLE
Fix compile_error argument error

### DIFF
--- a/librocksdb-sys/build.rs
+++ b/librocksdb-sys/build.rs
@@ -1,5 +1,5 @@
 #[cfg(all(feature = "portable", feature = "march-native"))]
-compile_error!("feature "portable" and feature "march_native" cannot be enabled at the same time");
+compile_error!("feature 'portable' and feature 'march-native' cannot be enabled at the same time");
 
 use std::env;
 use std::fs;


### PR DESCRIPTION

Fix error:

```console
error: compile_error! takes 1 argument
 --> /Users/yukang/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/ckb-librocksdb-sys-8.5.4/build.rs:2:1
  |
2 | compile_error!("feature "portable" and feature "march_native" cannot be enabled at the same time");
  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

```